### PR TITLE
Fontconfig and freetype support

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -46,6 +46,7 @@ jobs:
           docker run --rm -v $(pwd):/imgs im-fedora27 /imgs/test.pdf /imgs/test-pdf.png
           docker run --rm -v $(pwd):/imgs im-fedora27 -resize 200 /imgs/test.tiff /imgs/test-resize.tiff
           docker run --rm -v $(pwd):/imgs im-fedora27 -resize 200 /imgs/test.tiff webp:/imgs/test-tiff.webp
+          docker run --rm -v $(pwd):/imgs im-fedora27 /imgs/test.jpg -antialias -font NimbusRoman-Bold -pointsize 20 -gravity Southeast -annotate +15+15 'TEST' /imgs/test-text.jpg
       -
         name: Build Debian Stretch Image
         id: docker_build_stretch
@@ -69,6 +70,7 @@ jobs:
           docker run --rm -v $(pwd):/imgs im-stretch /imgs/jpg-with-metadata.jpg /imgs/jpg-with-metadata.webp
           docker run --rm -v $(pwd):/imgs im-stretch -resize 200 /imgs/test.tiff /imgs/test-resize.tiff
           docker run --rm -v $(pwd):/imgs im-stretch -resize 200 /imgs/test.tiff webp:/imgs/test-tiff.webp
+          docker run --rm -v $(pwd):/imgs im-stretch /imgs/test.jpg -antialias -font Helvetica-Bold -pointsize 20 -gravity Southeast -annotate +15+15 'TEST' /imgs/test-text.jpg
       -
         name: Build Debian Stretch Image
         id: docker_build_buster
@@ -95,3 +97,4 @@ jobs:
           docker run --rm -v $(pwd):/imgs im-buster -resize 200 /imgs/test.tiff /imgs/test-resize.tiff
           docker run --rm -v $(pwd):/imgs im-buster -resize 200 /imgs/test.tiff webp:/imgs/test-tiff.webp
           docker run --rm -v $(pwd):/imgs im-buster -resize 200 /imgs/test.tiff avif:/imgs/test-tiff.avif
+          docker run --rm -v $(pwd):/imgs im-buster /imgs/test.jpg -antialias -font Helvetica-Bold -pointsize 20 -gravity Southeast -annotate +15+15 'TEST' /imgs/test-text.jpg

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -44,6 +44,8 @@ jobs:
           docker run --rm -v $(pwd):/imgs im-fedora27 -resize 100 /imgs/test.png webp:/imgs/test-png.webp
           docker run --rm -v $(pwd):/imgs im-fedora27 -resize 100 /imgs/test.png jxr:/imgs/test-png.jxr
           docker run --rm -v $(pwd):/imgs im-fedora27 /imgs/test.pdf /imgs/test-pdf.png
+          docker run --rm -v $(pwd):/imgs im-fedora27 -resize 200 /imgs/test.tiff /imgs/test-resize.tiff
+          docker run --rm -v $(pwd):/imgs im-fedora27 -resize 200 /imgs/test.tiff webp:/imgs/test-tiff.webp
       -
         name: Build Debian Stretch Image
         id: docker_build_stretch
@@ -65,6 +67,8 @@ jobs:
           docker run --rm -v $(pwd):/imgs im-stretch -resize 100 /imgs/test.png webp:/imgs/test-png.webp
           docker run --rm -v $(pwd):/imgs im-stretch /imgs/test.pdf /imgs/test-pdf.png
           docker run --rm -v $(pwd):/imgs im-stretch /imgs/jpg-with-metadata.jpg /imgs/jpg-with-metadata.webp
+          docker run --rm -v $(pwd):/imgs im-stretch -resize 200 /imgs/test.tiff /imgs/test-resize.tiff
+          docker run --rm -v $(pwd):/imgs im-stretch -resize 200 /imgs/test.tiff webp:/imgs/test-tiff.webp
       -
         name: Build Debian Stretch Image
         id: docker_build_buster

--- a/Dockerfile.buster
+++ b/Dockerfile.buster
@@ -13,7 +13,7 @@ RUN apt-get -y update && \
     # libheif
     libde265-0 libde265-dev libjpeg62-turbo libjpeg62-turbo-dev x265 libx265-dev libtool \
     # IM
-    libpng16-16 libpng-dev libjpeg62-turbo libjpeg62-turbo-dev libgomp1 ghostscript libxml2-dev libxml2-utils libtiff-dev && \
+    libpng16-16 libpng-dev libjpeg62-turbo libjpeg62-turbo-dev libgomp1 ghostscript libxml2-dev libxml2-utils libtiff-dev libfontconfig1-dev libfreetype6-dev && \
     # Building libwebp
     git clone https://chromium.googlesource.com/webm/libwebp && \
     cd libwebp && git checkout v${LIB_WEBP_VERSION} && \
@@ -42,7 +42,7 @@ RUN apt-get -y update && \
     ./configure --without-magick-plus-plus --disable-docs --disable-static --with-libtiff && \
     make && make install && \
     ldconfig /usr/local/lib && \
-    apt-get remove --autoremove --purge -y gcc make cmake curl g++ yasm git autoconf pkg-config libpng-dev libjpeg62-turbo-dev libde265-dev libx265-dev libxml2-dev libtiff-dev && \
+    apt-get remove --autoremove --purge -y gcc make cmake curl g++ yasm git autoconf pkg-config libpng-dev libjpeg62-turbo-dev libde265-dev libx265-dev libxml2-dev libtiff-dev libfontconfig1-dev libfreetype6-dev && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /ImageMagick
 

--- a/Dockerfile.fedora27
+++ b/Dockerfile.fedora27
@@ -7,13 +7,13 @@ RUN dnf -y install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-re
 
 WORKDIR /opt
 
-RUN yum install -y libtool-ltdl libjpeg libjpeg-devel libpng libpng-devel libtiff libtiff-devel libwebp libwebp-devel LibRaw LibRaw-devel jxrlib git make automake gcc pkgconf ghostscript-core libxml2-devel && \
+RUN yum install -y libtool-ltdl libjpeg libjpeg-devel libpng libpng-devel libtiff libtiff-devel libwebp libwebp-devel LibRaw LibRaw-devel jxrlib git make automake gcc pkgconf ghostscript-core libxml2-devel fontconfig-devel freetype-devel && \
     git clone https://github.com/ImageMagick/ImageMagick.git && \
     cd ImageMagick && git checkout ${IM_VERSION} && \
     ./configure && make && make install && \
     cd ../ && \
     rm -rf ./ImageMagick && \
-    yum remove -y git make automake gcc libjpeg-devel libpng-devel libtiff-devel libwebp-devel LibRaw-devel && \
+    yum remove -y git make automake gcc libjpeg-devel libpng-devel libtiff-devel libwebp-devel LibRaw-devel fontconfig-devel freetype-devel && \
     yum clean all
 
 ENTRYPOINT ["convert"]

--- a/Dockerfile.stretch
+++ b/Dockerfile.stretch
@@ -5,12 +5,12 @@ ARG IM_VERSION=7.0.11-13
 RUN apt-get -y update && \
     apt-get -y upgrade && \
     apt-get -y install git make gcc pkg-config autoconf && \
-    apt-get -y install libpng16-16 libpng-dev libjpeg62-turbo libjpeg62-turbo-dev libwebp6 libwebp-dev libgomp1 libwebpmux2 libwebpdemux2 ghostscript libxml2-dev libxml2-utils libtiff-dev && \
+    apt-get -y install libpng16-16 libpng-dev libjpeg62-turbo libjpeg62-turbo-dev libwebp6 libwebp-dev libgomp1 libwebpmux2 libwebpdemux2 ghostscript libxml2-dev libxml2-utils libtiff-dev libfontconfig1-dev libfreetype6-dev && \
     git clone https://github.com/ImageMagick/ImageMagick.git && \
     cd ImageMagick && git checkout ${IM_VERSION} && \
     ./configure && make && make install && \
     ldconfig /usr/local/lib && \
-    apt-get remove --autoremove --purge -y gcc make git autoconf pkg-config libpng-dev libjpeg62-turbo-dev libwebp-dev libxml2-dev libtiff-dev && \
+    apt-get remove --autoremove --purge -y gcc make git autoconf pkg-config libpng-dev libjpeg62-turbo-dev libwebp-dev libxml2-dev libtiff-dev libfontconfig1-dev libfreetype6-dev && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /ImageMagick
 

--- a/Dockerfile.stretch
+++ b/Dockerfile.stretch
@@ -5,12 +5,12 @@ ARG IM_VERSION=7.0.11-13
 RUN apt-get -y update && \
     apt-get -y upgrade && \
     apt-get -y install git make gcc pkg-config autoconf && \
-    apt-get -y install libpng16-16 libpng-dev libjpeg62-turbo libjpeg62-turbo-dev libwebp6 libwebp-dev libgomp1 libwebpmux2 libwebpdemux2 ghostscript libxml2-dev libxml2-utils && \
+    apt-get -y install libpng16-16 libpng-dev libjpeg62-turbo libjpeg62-turbo-dev libwebp6 libwebp-dev libgomp1 libwebpmux2 libwebpdemux2 ghostscript libxml2-dev libxml2-utils libtiff-dev && \
     git clone https://github.com/ImageMagick/ImageMagick.git && \
     cd ImageMagick && git checkout ${IM_VERSION} && \
     ./configure && make && make install && \
     ldconfig /usr/local/lib && \
-    apt-get remove --autoremove --purge -y gcc make git autoconf pkg-config libpng-dev libjpeg62-turbo-dev libwebp-dev libxml2-dev && \
+    apt-get remove --autoremove --purge -y gcc make git autoconf pkg-config libpng-dev libjpeg62-turbo-dev libwebp-dev libxml2-dev libtiff-dev && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /ImageMagick
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ formats supported by different base images:
 
 | Base Image | Jpeg  | PNG   | JpegXR   | WebP   | AVIF   | PDF   | TIFF |
 | ---------- | :---: | :---: | :------: | :----: | :----: | :---: | :--: |
-| fedora27   | X     | X     | X        | X      |        | X     |      |
-| stretch    | X     | X     |          | X      |        | X     |      |
+| fedora27   | X     | X     | X        | X      |        | X     | X    |
+| stretch    | X     | X     |          | X      |        | X     | X    |
 | buster     | X     | X     |          | X      | X      | X     | X    |
 


### PR DESCRIPTION
Before this commit, when running convert commands overlaying text on an image,
ImageMagick would output the following warning:
```
convert: delegate library support not built-in '...' (Freetype) @ warning/annotate.c/RenderFreetype/1873
```

Even though text would render on the output image, the text looked pixelated.
Adding fontconfig and freetype to ImageMagick fixes this.

See the following link for more info:
https://web.archive.org/web/20210621064448/https://legacy.imagemagick.org/discourse-server/viewtopic.php?t=21070

The following is a comparison of the output from the existing
dpokidov/imagemagick Docker images and images built from this commit:

OUTPUT FROM EXISTING dpokidov/imagemagick DOCKER IMAGES:
```
$ docker run -it --rm dpokidov/imagemagick:latest -version
Version: ImageMagick 7.0.11-13 Q16 x86_64 2021-05-16 https://imagemagick.org
Copyright: (C) 1999-2021 ImageMagick Studio LLC
License: https://imagemagick.org/script/license.php
Features: Cipher DPC HDRI OpenMP(4.5)
Delegates (built-in): heic jbig jng jpeg lzma png tiff webp xml zlib

$ docker run --rm -v $(pwd):/imgs dpokidov/imagemagick:latest /imgs/test.jpg -antialias -font Helvetica-Bold -pointsize 20 -gravity Southeast -annotate +15+15 'TEST' /imgs/test-text.jpg
convert: delegate library support not built-in '/usr/share/fonts/type1/gsfonts/n019004l.pfb' (Freetype) @ warning/annotate.c/RenderFreetype/1873.
convert: delegate library support not built-in '/usr/share/fonts/type1/gsfonts/n019004l.pfb' (Freetype) @ warning/annotate.c/RenderFreetype/1873.

$ docker run -it --rm dpokidov/imagemagick:latest-stretch -version
Version: ImageMagick 7.0.11-13 Q16 x86_64 2021-05-16 https://imagemagick.org
Copyright: (C) 1999-2021 ImageMagick Studio LLC
License: https://imagemagick.org/script/license.php
Features: Cipher DPC HDRI OpenMP(4.5)
Delegates (built-in): jng jpeg png webp xml zlib

$ $ docker run --rm -v $(pwd):/imgs dpokidov/imagemagick:latest-stretch /imgs/test.jpg -antialias -font Helvetica-Bold -pointsize 20 -gravity Southeast -annotate +15+15 'TEST' /imgs/test-text.jpg
convert: delegate library support not built-in '/usr/share/fonts/type1/gsfonts/n019004l.pfb' (Freetype) @ warning/annotate.c/RenderFreetype/1873.
convert: delegate library support not built-in '/usr/share/fonts/type1/gsfonts/n019004l.pfb' (Freetype) @ warning/annotate.c/RenderFreetype/1873.

$ docker run -it --rm dpokidov/imagemagick:latest-fedora27 -version
Version: ImageMagick 7.0.11-13 Q16 x86_64 2021-05-16 https://imagemagick.org
Copyright: (C) 1999-2021 ImageMagick Studio LLC
License: https://imagemagick.org/script/license.php
Features: Cipher DPC HDRI OpenMP(4.5)
Delegates (built-in): jng jpeg lcms lzma png raw tiff webp xml zlib

$ docker run --rm -v $(pwd):/imgs dpokidov/imagemagick:latest-fedora27 /imgs/test.jpg -antialias -font NimbusRoman-Bold -pointsize 20 -gravity Southeast -annotate +15+15 'TEST' /imgs/test-text.jpg
convert: unable to read font `NimbusRoman-Bold' @ warning/annotate.c/RenderType/971.
convert: delegate library support not built-in 'NimbusRoman-Bold' (Freetype) @ warning/annotate.c/RenderFreetype/1873.
convert: unable to read font `NimbusRoman-Bold' @ warning/annotate.c/RenderType/971.
convert: delegate library support not built-in 'NimbusRoman-Bold' (Freetype) @ warning/annotate.c/RenderFreetype/1873.
```

OUTPUT FROM DOCKER IMAGES BUILT FROM THIS COMMIT:
```
$ docker run -it --rm im-fedora27:latest -version
Version: ImageMagick 7.0.11-13 Q16 x86_64 2021-05-16 https://imagemagick.org
Copyright: (C) 1999-2021 ImageMagick Studio LLC
License: https://imagemagick.org/script/license.php
Features: Cipher DPC HDRI OpenMP(4.5)
Delegates (built-in): bzlib fontconfig freetype jng jpeg lcms lzma png raw tiff webp xml zlib

$ docker run --rm -v $(pwd):/imgs im-fedora27 /imgs/test.jpg -antialias -font NimbusRoman-Bold -pointsize 20 -gravity Southeast -annotate +15+15 'TEST' /imgs/test-text.jpg

$ docker run -it --rm im-stretch:latest -version
Version: ImageMagick 7.0.11-13 Q16 x86_64 2021-05-16 https://imagemagick.org
Copyright: (C) 1999-2021 ImageMagick Studio LLC
License: https://imagemagick.org/script/license.php
Features: Cipher DPC HDRI OpenMP(4.5)
Delegates (built-in): fontconfig freetype jbig jng jpeg lzma png tiff webp xml zlib

$ docker run --rm -v $(pwd):/imgs im-stretch /imgs/test.jpg -antialias -font Helvetica-Bold -pointsize 20 -gravity Southeast -annotate +15+15 'TEST' /imgs/test-text.jpg

$ docker run -it --rm im-buster:latest -version
Version: ImageMagick 7.0.11-13 Q16 x86_64 2021-05-16 https://imagemagick.org
Copyright: (C) 1999-2021 ImageMagick Studio LLC
License: https://imagemagick.org/script/license.php
Features: Cipher DPC HDRI OpenMP(4.5)
Delegates (built-in): fontconfig freetype heic jbig jng jpeg lzma png tiff webp xml zlib

$ docker run --rm -v $(pwd):/imgs im-buster /imgs/test.jpg -antialias -font Helvetica-Bold -pointsize 20 -gravity Southeast -annotate +15+15 'TEST' /imgs/test-text.jpg
```