### PR TITLE
remove entrypoint

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -47,5 +47,3 @@ RUN apt-get -y update && \
     apt-get remove --autoremove --purge -y gcc make cmake curl g++ yasm git autoconf pkg-config libpng-dev libjpeg-turbo8-dev libde265-dev libx265-dev libxml2-dev libtiff-dev libfontconfig1-dev libfreetype6-dev && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /ImageMagick
-
-ENTRYPOINT ["convert"]


### PR DESCRIPTION
Hello,

I want to build a Docker image using `Dockerfile.ubuntu` as the base. 

Since my Dockerfile is already defining an entrypoint, I was thinking if I drop the current entrypoint here will enable users to extend the image rather than limiting it.

I added it because it's present in the rest of the images, but I'm not sure if that is something just for illustrating purposes or actually it has an intention.