### PR TITLE
Remove DockerFile entrypoint

### DIFF
--- a/Dockerfile.bullseye
+++ b/Dockerfile.bullseye
@@ -48,4 +48,4 @@ RUN apt-get -y update && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /ImageMagick
 
-CMD ["convert"]
+CMD ["magick"]

--- a/Dockerfile.bullseye
+++ b/Dockerfile.bullseye
@@ -48,4 +48,4 @@ RUN apt-get -y update && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /ImageMagick
 
-ENTRYPOINT ["convert"]
+CMD ["convert"]

--- a/Dockerfile.buster
+++ b/Dockerfile.buster
@@ -48,4 +48,4 @@ RUN apt-get -y update && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /ImageMagick
 
-CMD ["convert"]
+CMD ["magick"]

--- a/Dockerfile.buster
+++ b/Dockerfile.buster
@@ -48,4 +48,4 @@ RUN apt-get -y update && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /ImageMagick
 
-ENTRYPOINT ["convert"]
+CMD ["convert"]

--- a/Dockerfile.fedora27
+++ b/Dockerfile.fedora27
@@ -16,4 +16,4 @@ RUN yum install -y libtool-ltdl libjpeg libjpeg-devel libpng libpng-devel libtif
     yum remove -y git make automake gcc libjpeg-devel libpng-devel libtiff-devel libwebp-devel LibRaw-devel fontconfig-devel freetype-devel && \
     yum clean all
 
-ENTRYPOINT ["convert"]
+CMD ["convert"]

--- a/Dockerfile.fedora27
+++ b/Dockerfile.fedora27
@@ -16,4 +16,4 @@ RUN yum install -y libtool-ltdl libjpeg libjpeg-devel libpng libpng-devel libtif
     yum remove -y git make automake gcc libjpeg-devel libpng-devel libtiff-devel libwebp-devel LibRaw-devel fontconfig-devel freetype-devel && \
     yum clean all
 
-CMD ["convert"]
+CMD ["magick"]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -48,4 +48,4 @@ RUN apt-get -y update && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /ImageMagick
 
-CMD ["convert"]
+CMD ["magick"]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -48,4 +48,4 @@ RUN apt-get -y update && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /ImageMagick
 
-ENTRYPOINT ["convert"]
+CMD ["convert"]


### PR DESCRIPTION
In any case, the command to be used should be [CMD](https://phoenixnap.com/kb/docker-cmd-vs-entrypoint):

> In short, CMD defines default commands and/or parameters for a container. CMD is an instruction that is best to use if you need a default command which users can easily override. If a Dockerfile has multiple CMDs, it only applies the instructions from the last one.

But I don't think exposing a standalone `convert` makes sense in this case, since the image is adding a lot of useful binaries that can be used by the end-user. Instead, leaving the Dockerfile ready to be used by user commands.
